### PR TITLE
 Security: Mask API key in Settings and only overwrite when non-empty (v1.3.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ SlackConversation2DecisionCardPlugin/
 - **Product Requirements**: Complete specifications in `docs/prd.md`
 - **Development Guidelines**: Project standards and practices in `CLAUDE.md`
 
+## 🔒 Security Notes
+
+- The plugin does not render the stored API key back into the Settings UI. The API key field stays blank with a neutral placeholder.
+- Submitting an empty API key keeps the existing key unchanged; submitting a non‑empty key overwrites the stored key.
+- New API keys are saved with autoload disabled to minimize exposure and memory footprint.
+
 ## 🛠️ Development
 
 This is a 1-week MVP build following WordPress plugin development standards:

--- a/ai-decision-cards/admin/class-admin-ajax.php
+++ b/ai-decision-cards/admin/class-admin-ajax.php
@@ -59,6 +59,10 @@ class AdminAjax {
 		// Get form data
 		$api_type = isset( $_POST['api_type'] ) ? sanitize_text_field( $_POST['api_type'] ) : 'openai';
 		$api_key = isset( $_POST['api_key'] ) ? sanitize_text_field( $_POST['api_key'] ) : '';
+		// If no API key provided in the request, fall back to the stored option.
+		if ( empty( $api_key ) ) {
+			$api_key = (string) get_option( \AIDC\Admin\Admin::OPTION_API_KEY );
+		}
 		$api_base = isset( $_POST['api_base'] ) ? sanitize_text_field( $_POST['api_base'] ) : '';
 		$model = isset( $_POST['model'] ) ? sanitize_text_field( $_POST['model'] ) : '';
 		

--- a/ai-decision-cards/admin/class-admin-assets.php
+++ b/ai-decision-cards/admin/class-admin-assets.php
@@ -64,24 +64,32 @@ class AdminAssets {
 		);
 		
 		if ( in_array( $screen->id, $target_pages, true ) ) {
+			$base_url  = plugin_dir_url( AIDC_PLUGIN_FILE ) . 'assets/';
+			$base_path = plugin_dir_path( AIDC_PLUGIN_FILE ) . 'assets/';
+			
+			$ver_public_css = file_exists( $base_path . 'css/public.css' ) ? filemtime( $base_path . 'css/public.css' ) : AIDC_VERSION;
+			$ver_admin_css  = file_exists( $base_path . 'css/admin.css' ) ? filemtime( $base_path . 'css/admin.css' ) : AIDC_VERSION;
+			$ver_admin_js   = file_exists( $base_path . 'js/admin.js' ) ? filemtime( $base_path . 'js/admin.js' ) : AIDC_VERSION;
+			$ver_public_js  = file_exists( $base_path . 'js/public.js' ) ? filemtime( $base_path . 'js/public.js' ) : AIDC_VERSION;
+
 			// Public styles are also needed for previewing display inside admin
 			wp_enqueue_style(
 				'aidc-public',
-				plugin_dir_url( AIDC_PLUGIN_FILE ) . 'assets/css/public.css',
+				$base_url . 'css/public.css',
 				array(),
-				AIDC_VERSION
+				$ver_public_css
 			);
 			wp_enqueue_style(
 				'aidc-admin',
-				plugin_dir_url( AIDC_PLUGIN_FILE ) . 'assets/css/admin.css',
+				$base_url . 'css/admin.css',
 				array(),
-				AIDC_VERSION
+				$ver_admin_css
 			);
 			wp_enqueue_script(
 				'aidc-admin',
-				plugin_dir_url( AIDC_PLUGIN_FILE ) . 'assets/js/admin.js',
+				$base_url . 'js/admin.js',
 				array( 'jquery' ),
-				AIDC_VERSION,
+				$ver_admin_js,
 				true
 			);
 
@@ -89,9 +97,9 @@ class AdminAssets {
 			if ( in_array( $screen->id, array( 'decision_card_page_aidc_display', 'toplevel_page_decision-cards-display' ), true ) ) {
 				wp_enqueue_script(
 					'aidc-public',
-					plugin_dir_url( AIDC_PLUGIN_FILE ) . 'assets/js/public.js',
+					$base_url . 'js/public.js',
 					array(),
-					AIDC_VERSION,
+					$ver_public_js,
 					true
 				);
 			}

--- a/ai-decision-cards/admin/class-admin.php
+++ b/ai-decision-cards/admin/class-admin.php
@@ -133,11 +133,12 @@ class Admin {
 
 		// Prepare data for the view
 		$view_data = array(
-			'saved' => false,
-			'api_type' => get_option( self::OPTION_API_TYPE, 'openai' ),
-			'api_key' => \AIDC\Includes\Helpers::get_option_attr( self::OPTION_API_KEY, '' ),
-			'api_base' => \AIDC\Includes\Helpers::get_option_attr( self::OPTION_API_BASE, 'https://api.openai.com/' ),
-			'model' => \AIDC\Includes\Helpers::get_option_attr( self::OPTION_MODEL, 'gpt-3.5-turbo' ),
+			'saved'   => false,
+			'api_type'=> get_option( self::OPTION_API_TYPE, 'openai' ),
+			// Do not expose stored API key back into the DOM
+			'api_key' => '',
+			'api_base'=> \AIDC\Includes\Helpers::get_option_attr( self::OPTION_API_BASE, 'https://api.openai.com/' ),
+			'model'   => \AIDC\Includes\Helpers::get_option_attr( self::OPTION_MODEL, 'gpt-3.5-turbo' ),
 		);
 
 		// Handle form submission
@@ -146,7 +147,12 @@ class Admin {
 				update_option( self::OPTION_API_TYPE, sanitize_text_field( wp_unslash( $_POST['aidc_api_type'] ) ) );
 			}
 			if ( isset( $_POST['aidc_api_key'] ) ) {
-				update_option( self::OPTION_API_KEY, sanitize_text_field( wp_unslash( $_POST['aidc_api_key'] ) ) );
+				$maybe_key = trim( sanitize_text_field( wp_unslash( $_POST['aidc_api_key'] ) ) );
+				// Only overwrite stored key when a non-empty value is submitted.
+				if ( '' !== $maybe_key ) {
+					// Ensure the option is stored without autoloading for security.
+					update_option( self::OPTION_API_KEY, $maybe_key, 'no' );
+				}
 			}
 			if ( isset( $_POST['aidc_api_base'] ) ) {
 				$base = trim( sanitize_text_field( wp_unslash( $_POST['aidc_api_base'] ) ) );
@@ -162,9 +168,10 @@ class Admin {
 			$view_data['saved'] = true;
 			// Refresh data after save
 			$view_data['api_type'] = get_option( self::OPTION_API_TYPE, 'openai' );
-			$view_data['api_key'] = \AIDC\Includes\Helpers::get_option_attr( self::OPTION_API_KEY, '' );
+			// Keep API key field empty after save; never repopulate with stored value.
+			$view_data['api_key']  = '';
 			$view_data['api_base'] = \AIDC\Includes\Helpers::get_option_attr( self::OPTION_API_BASE, 'https://api.openai.com/' );
-			$view_data['model'] = \AIDC\Includes\Helpers::get_option_attr( self::OPTION_MODEL, 'gpt-3.5-turbo' );
+			$view_data['model']    = \AIDC\Includes\Helpers::get_option_attr( self::OPTION_MODEL, 'gpt-3.5-turbo' );
 		}
 
 		// Render view

--- a/ai-decision-cards/admin/views/changelog.php
+++ b/ai-decision-cards/admin/views/changelog.php
@@ -19,41 +19,46 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<h1><?php esc_html_e( 'Changelog', 'ai-decision-cards' ); ?></h1>
 	<p><?php esc_html_e( 'What\'s new and improved in AI Decision Cards.', 'ai-decision-cards' ); ?></p>
 
+	<h2>1.3.1</h2>
+	<ul>
+		<li><?php esc_html_e( 'Safer settings: Your API key stays hidden on the page. Leave the field blank to keep your current key.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Easier testing: “Test API Key” works even if the field is blank (it uses your saved key).', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Smoother updates: Admin screens refresh their assets more reliably after updates.', 'ai-decision-cards' ); ?></li>
+	</ul>
+	<p><em><?php echo wp_kses_post( sprintf( __( 'Want the technical details? See the %s.', 'ai-decision-cards' ), '<a href="https://github.com/sunnypsk/SlackConversation2DecisionCardPlugin/releases" target="_blank" rel="noopener noreferrer">' . esc_html__( 'release notes on GitHub', 'ai-decision-cards' ) . '</a>' ) ); ?></em></p>
+
 	<h2>1.3.0</h2>
 	<ul>
-		<li><?php esc_html_e( 'Major: Complete plugin architecture refactor for better maintainability and performance.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'New: Modular class-based design with proper namespace organization.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'New: Improved CSS organization with all inline styles moved to dedicated files.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'Improved: Enhanced JavaScript event handling with modern best practices.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'Improved: Better separation of concerns between business logic and presentation.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'Developer: Reduced main plugin file from 1600+ to 67 lines of code.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'Developer: Enhanced code maintainability with shared utility classes.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Under‑the‑hood refresh for a faster, more reliable experience.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Cleaner screens and smoother interactions across admin and public pages.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'More consistent styling and scripts to reduce quirks.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Stronger foundation to support future features and updates.', 'ai-decision-cards' ); ?></li>
 	</ul>
 
 	<h2>1.2.1</h2>
 	<ul>
-		<li><?php esc_html_e( 'New: Translation-ready with a template so you can add your language.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'New: One-click public Decision Cards page from the admin menu.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'Improved: Simpler filters with a quick Reset for faster browsing.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'Improved: Clearer messages and guidance during generation.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'Stability: General reliability and security improvements.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Now supports translations — add your language easily.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Added a one‑click public Decision Cards page from the menu.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Simpler filters with a quick Reset for faster browsing.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Clearer messages and guidance while generating.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'General stability and security improvements.', 'ai-decision-cards' ); ?></li>
 	</ul>
 
 	<h2>1.2.0</h2>
 	<ul>
-		<li><?php esc_html_e( 'New: Easy shortcodes to list and embed cards anywhere.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'New: Search across titles and full card content.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'New: Filter by status and owner to find decisions quickly.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'New: Public display option to share decisions with stakeholders.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'Improved: Copy-and-paste shortcodes and responsive layouts.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'New shortcodes to list and embed Decision Cards anywhere.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Search across titles and full card content.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Filter by status and owner to find decisions quickly.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Public display to share decisions with stakeholders.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Copy‑and‑paste shortcodes and responsive layouts.', 'ai-decision-cards' ); ?></li>
 	</ul>
 
 	<h2>1.1.0</h2>
 	<ul>
-		<li><?php esc_html_e( 'New: Standard 5-section layout for consistent Decision Cards.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'New: Status banner showing Status | Owner | Target.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'Improved: Smarter date handling and better previews.', 'ai-decision-cards' ); ?></li>
-		<li><?php esc_html_e( 'Improved: Higher-quality AI output and cleaner rendering.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Consistent 5‑section Decision Card layout.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Status banner shows Status | Owner | Target.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Smarter date handling and better previews.', 'ai-decision-cards' ); ?></li>
+		<li><?php esc_html_e( 'Cleaner output for easier reading.', 'ai-decision-cards' ); ?></li>
 	</ul>
 
 	<h2>1.0.0</h2>

--- a/ai-decision-cards/admin/views/settings.php
+++ b/ai-decision-cards/admin/views/settings.php
@@ -52,11 +52,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<label for="aidc_api_key"><span id="api_key_label"><?php esc_html_e( 'API Key', 'ai-decision-cards' ); ?></span></label>
 				</th>
 				<td>
-					<input type="password" id="aidc_api_key" name="aidc_api_key" 
-						   value="<?php echo $api_key; ?>" 
-						   class="regular-text" />
+					<input type="password" id="aidc_api_key" name="aidc_api_key"
+					       value=""
+					       placeholder="••••••"
+					       autocomplete="new-password"
+					       class="regular-text" />
 					<p class="description" id="api_key_desc">
 						<?php esc_html_e( 'Your API key for OpenAI, OpenRouter, or other compatible services.', 'ai-decision-cards' ); ?>
+						<br />
+						<?php esc_html_e( 'For security, the saved key is not shown. Leave this field blank to keep your existing key.', 'ai-decision-cards' ); ?>
 					</p>
 				</td>
 			</tr>

--- a/ai-decision-cards/ai-decision-cards.php
+++ b/ai-decision-cards/ai-decision-cards.php
@@ -3,7 +3,7 @@
  * Plugin Name: AI Decision Cards
  * Plugin URI: https://github.com/sunnypsk/SlackConversation2DecisionCardPlugin
  * Description: Convert Slack-style conversations into AI-generated Decision Cards with summaries and action items using OpenAI-compatible APIs.
- * Version: 1.3.0
+ * Version: 1.3.1
  * Author: Sunny Poon
  * License: GPL v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'AIDC_VERSION', '1.3.0' );
+define( 'AIDC_VERSION', '1.3.1' );
 define( 'AIDC_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'AIDC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'AIDC_PLUGIN_FILE', __FILE__ );

--- a/ai-decision-cards/assets/js/admin.js
+++ b/ai-decision-cards/assets/js/admin.js
@@ -4,14 +4,13 @@
 
 	function toggleApiFields(){
 		var apiKeyLabel = qs('#api_key_label');
-		var apiKeyDesc = qs('#api_key_desc');
 		var apiBaseLabel = qs('#api_base_label');
 		var apiBaseDesc = qs('#api_base_desc');
 		var modelLabel = qs('#model_label');
 		var modelDesc = qs('#model_desc');
 		if(!apiKeyLabel) return;
+		// Keep server-rendered descriptions intact (avoid overwriting additional security notes)
 		apiKeyLabel.textContent = 'API Key';
-		if(apiKeyDesc) apiKeyDesc.textContent = 'Your API key for OpenAI, OpenRouter, or other compatible services.';
 		if(apiBaseLabel) apiBaseLabel.textContent = 'API Base URL';
 		if(apiBaseDesc) apiBaseDesc.textContent = 'Example: https://api.openai.com/ or https://openrouter.ai/api/v1/';
 		if(modelLabel) modelLabel.textContent = 'Model';
@@ -31,15 +30,12 @@
 		if(apiTypeSelect){
 			apiTypeSelect.addEventListener('change', toggleApiFields);
 		}
-		testBtn.addEventListener('click', function(){
+			testBtn.addEventListener('click', function(){
 			var apiType = qs('#aidc_api_type') ? qs('#aidc_api_type').value : 'openai';
 			var apiKey = qs('#aidc_api_key') ? qs('#aidc_api_key').value : '';
 			var apiBase = qs('#aidc_api_base') ? qs('#aidc_api_base').value : '';
 			var model = qs('#aidc_model') ? qs('#aidc_model').value : '';
-			if(!apiKey.trim()){
-				if(resultDiv){ resultDiv.innerHTML = '<div class="notice notice-error"><p>'+ (aidcAdmin && aidcAdmin.i18n ? aidcAdmin.i18n.pleaseEnterKey : 'Please enter an API key first.') +'</p></div>'; }
-				return;
-			}
+			// Allow empty apiKey here; server will fall back to stored key if available.
 			testBtn.disabled = true;
 			testBtn.textContent = (aidcAdmin && aidcAdmin.i18n ? aidcAdmin.i18n.testing : 'Testing...');
 			if(resultDiv){ resultDiv.innerHTML = '<div class="notice notice-info"><p>'+ (aidcAdmin && aidcAdmin.i18n ? aidcAdmin.i18n.testingConnection : 'Testing API connection...') +'</p></div>'; }

--- a/ai-decision-cards/public/class-public-assets.php
+++ b/ai-decision-cards/public/class-public-assets.php
@@ -48,18 +48,24 @@ class PublicAssets {
 	 */
 	public function enqueue_public_assets() {
 		// Always load public CSS since shortcodes may appear on any page
+		$base_url  = plugin_dir_url( AIDC_PLUGIN_FILE ) . 'assets/';
+		$base_path = plugin_dir_path( AIDC_PLUGIN_FILE ) . 'assets/';
+		
+		$ver_public_css = file_exists( $base_path . 'css/public.css' ) ? filemtime( $base_path . 'css/public.css' ) : AIDC_VERSION;
+		$ver_public_js  = file_exists( $base_path . 'js/public.js' ) ? filemtime( $base_path . 'js/public.js' ) : AIDC_VERSION;
+
 		wp_enqueue_style(
 			'aidc-public',
-			plugin_dir_url( AIDC_PLUGIN_FILE ) . 'assets/css/public.css',
+			$base_url . 'css/public.css',
 			array(),
-			AIDC_VERSION
+			$ver_public_css
 		);
 
 		wp_enqueue_script(
 			'aidc-public',
-			plugin_dir_url( AIDC_PLUGIN_FILE ) . 'assets/js/public.js',
+			$base_url . 'js/public.js',
 			array(),
-			AIDC_VERSION,
+			$ver_public_js,
 			true
 		);
 	}

--- a/ai-decision-cards/readme.md
+++ b/ai-decision-cards/readme.md
@@ -72,10 +72,17 @@ Transform your team's conversation transcripts into professional Decision Cards 
 1. Navigate to **Decision Cards → Settings** in your WordPress admin
 2. Configure your API settings:
    - **API Type**: Choose between OpenAI or OpenAI Compatible
-   - **API Key**: Enter your OpenAI API key (required)
+   - **API Key**: Enter your OpenAI API key (required). For security, the saved key is never shown on the page; the field stays blank with a placeholder. Leave it blank to keep your existing key unchanged.
    - **API Base URL**: Default is `https://api.openai.com/` (change for OpenRouter or other services)
    - **Model**: Default is `gpt-3.5-turbo` (can use `gpt-4` or other chat models)
-3. Test your API connection using the built-in test feature
+   3. Test your API connection using the built-in test feature
+
+### Security: API Key Handling
+
+- The API key field on the Settings page never repopulates with the stored value; it shows a neutral placeholder only.
+- Saving an empty API key leaves the existing stored key unchanged.
+- When a new (non-empty) key is submitted, it overwrites the stored key and is saved with autoload disabled to avoid being loaded into memory on every request.
+- The “Test API Key” button will use the typed value when provided; if left blank, it securely uses the currently stored key for testing.
 
 ## Usage
 
@@ -162,6 +169,12 @@ This plugin follows WordPress coding standards and best practices:
 - Responsive CSS design principles
 
 ## Changelog
+
+### 1.3.1
+- Security: API key is no longer repopulated in the Settings UI; the field remains blank with a neutral placeholder.
+- Security: Saving a blank API key keeps the existing key unchanged; new keys are saved with autoload disabled.
+- UX: “Test API Key” uses the entered value when provided, otherwise securely falls back to the stored key.
+- DX: Switched asset versioning to file modification time (per-file) to reduce cache issues in admin and public assets.
 
 ### 1.3.0
 - Refactor: Switched to modular architecture with a central `Plugin` orchestrator


### PR DESCRIPTION
 - Bump plugin version to 1.3.1 in main files
  - Add security notes in README regarding API key visibility and handling
  - Ensure API key field remains blank in settings UI, preventing exposure of stored keys
  - Implement logic to keep existing API key unchanged if the field is left blank
  - Update changelog with new security features and improvements in asset versioning for better cache management

  # Pull Request

  ## 📝 Description

  This PR hardens the Settings UI and storage behavior for the API key:

  - The saved key is never re-inserted into the DOM.
  - Saving with an empty key keeps the existing key unchanged.
  - New keys are stored with autoload disabled.
  - “Test API Key” works even if the field is blank by using the stored key.
  - Asset versioning now uses file modification time to avoid stale JS/CSS in admin and public views.

  Fixes #1

  ## 🎯 Type of Change

  - [x] ✨ New feature (non-breaking change that adds functionality)
  - [x] 📚 Documentation update
  - [x] ♻️ Refactoring (no functional changes) — asset versioning

  ## 🔄 Changes Made

  - Settings UI: keep API key input empty with neutral placeholder and security note (no DOM repopulation).
  - Save logic: only overwrite the stored key when a non-empty value is submitted; store with autoload = 'no'.
  - Test button: if field is blank, server falls back to the stored key for connectivity testing.
  - Asset cache-busting: version admin/public CSS/JS via filemtime() to reduce cache issues.
  - Version bump: 1.3.1.
  - Docs:
      - ai-decision-cards/readme.md: configuration + security notes; changelog 1.3.1.
      - README.md: security notes section.
      - Admin Changelog page: user-friendly wording for 1.3.1 (and earlier entries).

  ## 🧪 Testing

  Manual Testing

  - [x] WordPress 6.0+
  - [x] PHP 7.4+
  - [x] “Test API Key” with blank field uses stored key (if present)
  - [x] Saving a blank key keeps the existing key
  - [x] Entering a new key overwrites the stored key
  - [x] Assets reload after update (URLs include ?ver=<mtime>)

  Test Cases

  1. Blank Key Save
      - Steps: Go to Settings → leave API Key empty → Save.
      - Expected: Stored key unchanged; success notice; field remains blank.
  2. New Key Save
      - Steps: Enter a new API key → Save.
      - Expected: Stored key updated; key saved with autoload = 'no'.
  3. Test Button Fallback
      - Steps: Leave API Key field blank → click “Test API Key”.
      - Expected: Uses stored key; success/error based on actual connectivity.
  4. Asset Cache Busting
      - Steps: Hard refresh Settings/Public display → confirm asset URLs end with ?ver=<timestamp>.
      - Expected: New JS/CSS is loaded.

  ## 📷 Screenshots (if applicable)

  Before/After: Security note visible; API key field remains blank with placeholder.

  ## 🔍 Checklist

  Code Quality

  - [x] WordPress coding standards
  - [x] Self-review completed
  - [x] Documentation updated (README + changelog)

  Security & Best Practices

  - [x] Inputs sanitized
  - [x] Outputs escaped
  - [x] Nonces used for forms/AJAX
  - [x] Capabilities checked
  - [x] No hardcoded secrets

  WordPress Compatibility

  - [x] WordPress 6.0+
  - [x] Follows plugin best practices

  Documentation

  - [x] README sections updated
  - [x] Admin changelog updated
  - [x] Version numbers updated

  ## 🔗 Related Issues

  - Closes #1

  ## 🚀 Deployment Notes

  - No database migrations.
  - Clear plugin/theme caches if asset URLs are heavily cached.
  - Optional: Review autoload setting on existing installs if keys were saved previously.

  ## 📋 Additional Notes

  - Large diffs may be due to mixed line endings. Review with “Hide whitespace changes” to focus on logic changes.
  - Future improvement: optional “Clear API key” button for deliberate removal.
